### PR TITLE
Installation test on OpenShift

### DIFF
--- a/base/pipeline-params.env
+++ b/base/pipeline-params.env
@@ -1,1 +1,2 @@
 cacheImage=quay.io/ibm/busybox:1.35.0
+appVersion=2.0.0-alpha.7

--- a/install_kubeflow.sh
+++ b/install_kubeflow.sh
@@ -193,7 +193,7 @@ then
    echo "Helm not found - installing to /user/local/bin/..."
    helm_version=3.11.2
    curl --silent --location --remote-name "https://get.helm.sh/helm-v${helm_version}-linux-ppc64le.tar.gz"
-   tar --strip-components=1 -xzf helm-v${helm_version}-linux-ppc64le.tar.gz ./linux-ppc64le/helm
+   tar --strip-components=1 -xzf helm-v${helm_version}-linux-ppc64le.tar.gz linux-ppc64le/helm
    chmod a+x helm
    sudo mv helm /usr/local/bin/helm
    rm -f helm-v${helm_version}-linux-ppc64le.tar.gz

--- a/install_kubeflow.sh
+++ b/install_kubeflow.sh
@@ -51,6 +51,14 @@ case "$kubernetes_environment" in
         fi 
       fi
       
+      oc whoami &> /dev/null
+
+      if [[ $? -ne 0 ]]
+      then
+        echo "You did not log into the OpenShift api server, please login and re-run the script."
+        return
+      fi
+
       clusterDomain=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})
       echo -e ""
       read -p "${BOLD}Install OpenShift operators (Cert-Manager, Service Mesh (incl. Elasticsearch, Kiali, Jaeger), Namespace-Configuration, Serverless, Node Feature Discovery, GPU Operator, Grafana)?${NORMAL} [y]: " install_operators

--- a/overlays/openshift/servicemesh/controlplane.yaml
+++ b/overlays/openshift/servicemesh/controlplane.yaml
@@ -3,7 +3,7 @@ kind: ServiceMeshControlPlane
 metadata:
   name: kubeflow
 spec:
-  version: v2.1
+  version: v2.6
   proxy:
     injection:
       autoInject: true

--- a/overlays/openshift/servicemesh/envoyfilters.yaml
+++ b/overlays/openshift/servicemesh/envoyfilters.yaml
@@ -34,13 +34,13 @@ spec:
         listener:
           filterChain:
             filter:
-              name: envoy.http_connection_manager
+              name: envoy.filters.network.http_connection_manager
       patch:
         operation: MERGE
         value:
           typed_config:
             '@type': >-
-              type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+              type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
             tracing:
               custom_tags:
                 - request_header:
@@ -59,13 +59,13 @@ spec:
         listener:
           filterChain:
             filter:
-              name: envoy.http_connection_manager
+              name: envoy.filters.network.http_connection_manager
       patch:
         operation: MERGE
         value:
           typed_config:
             '@type': >-
-              type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+              type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
             tracing:
               custom_tags:
                 - request_header:

--- a/overlays/openshift/subscriptions/namespaces.yaml
+++ b/overlays/openshift/subscriptions/namespaces.yaml
@@ -12,3 +12,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nfd
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana

--- a/overlays/openshift/subscriptions/operatorgroups.yaml
+++ b/overlays/openshift/subscriptions/operatorgroups.yaml
@@ -25,3 +25,13 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-nfd
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: grafana-
+  name: grafana
+  namespace: grafana
+spec:
+  targetNamespaces:
+  - grafana

--- a/uninstall_kubeflow.sh
+++ b/uninstall_kubeflow.sh
@@ -88,6 +88,8 @@ case "$kubernetes_environment" in
 oc delete --all -A inferenceservices.serving.kserve.io 
 oc delete --kustomize $KUBEFLOW_KUSTOMIZE
 oc delete --kustomize $KUBEFLOW_KUSTOMIZE/servicemesh
+# uninstall gpu operator and remote the associated resources
+helm list --no-headers=true -n gpu-operator | awk '{print $1}' | xargs helm uninstall -n gpu-operator
 #############################################
 ;;
 2 ) # k8s


### PR DESCRIPTION
Tested on OpenShift 4.14.24.

Major changes:
1. Create a namespace and operator group for grafana
2. Update the version of service mesh control plane
3. Replace the deprecated filter and envoy filter configuration
4. Downgrade the version of kubeflow frontend and visualization-server to 2.0.0-alpha.7
5. Add script to uninstall gpu operator in OpenShift

Unresolved issues:
1. This image is not for ppc64le, change to use image quay.io/ibm/kubeflow-visualization-server-ppc64le:1.8.1 to start the pod
    quay.io/rocketaihub/visualization-server:v1.8.0
2. These two images don't exist, have to use images with tag 2.0.0-alpha.7 as a workaround
    quay.io/ibm/kubeflow-frontend-ppc64le:2.0.3
    quay.io/ibm/kubeflow-visualization-server-ppc64le:2.0.3
3. metadata-write pod cannot start successfully, below is the error message
```
Traceback (most recent call last):
File "/kfp/metadata_writer/metadata_writer.py", line 20, in <module>
import kubernetes
ModuleNotFoundError: No module named 'kubernetes'
```


